### PR TITLE
Fix for upcoming purrr 1.2.0 release

### DIFF
--- a/R/moranajp.R
+++ b/R/moranajp.R
@@ -468,7 +468,7 @@ html_radio_set <- function(form, ...){
 #' @export
 is_radio <- function(fields){
   fields |>
-    purrr::map_chr(`$`, "type") |>
+    purrr::map_chr("type") |>
     purrr::map_lgl(`==`, "radio")
 }
 


### PR DESCRIPTION
For performance reasons, `map()` and friends no longer process primitive functions quite the same way. Fortunately, you can use one of the built-in helpers instead.